### PR TITLE
Fix args/commandArgs, bump version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.github.tobi406'
-version '1.0-BETA'
+version '1.1-BETA'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/github/tobi406/aliasr/AliasrCommand.java
+++ b/src/main/java/com/github/tobi406/aliasr/AliasrCommand.java
@@ -16,7 +16,7 @@ public class AliasrCommand implements RawCommand {
             Component.text((invocation.source().hasPermission("aliasr.reload") ? "Reloaded " : "Running "))
                 .append(Component.text("Aliasr").color(NamedTextColor.AQUA))
                 .append(Component.text(" version "))
-                .append(Component.text("1.0-BETA").color(NamedTextColor.AQUA))
+                .append(Component.text("1.1-BETA").color(NamedTextColor.AQUA))
         );
     }
 }

--- a/src/main/java/com/github/tobi406/aliasr/AliasrPlugin.java
+++ b/src/main/java/com/github/tobi406/aliasr/AliasrPlugin.java
@@ -21,7 +21,7 @@ import java.util.List;
 @Plugin(
         id = "aliasr",
         name = "Aliasr",
-        version = "1.0-BETA",
+        version = "1.1-BETA",
         description = "Simple Alias manager using RegEx",
         authors = { "Tobi406" }
 )

--- a/src/main/java/com/github/tobi406/aliasr/AliasrPlugin.java
+++ b/src/main/java/com/github/tobi406/aliasr/AliasrPlugin.java
@@ -98,7 +98,7 @@ public class AliasrPlugin {
 
                 @Override
                 public void execute(Invocation invocation) {
-                    String joinedArgs = String.join(" ", args);
+                    String joinedArgs = String.join(" ", invocation.arguments());
 
                     AliasrPlugin.getInstance().commandManager.executeAsync(
                         invocation.source(),


### PR DESCRIPTION
In the latest build (compiled from master), commands using args/commandArgs don't work properly; this is due to a typo in `AliasrPlugin.java`.
I've fixed this and also bumped the version number.